### PR TITLE
Make FastSAMPrompt able to operate on tensors

### DIFF
--- a/fastsam/predict.py
+++ b/fastsam/predict.py
@@ -20,7 +20,11 @@ class FastSAMPredictor(DetectionPredictor):
                                     max_det=self.args.max_det,
                                     nc=len(self.model.names),
                                     classes=self.args.classes)
-        
+
+        results = []
+        if len(p) == 0 or len(p[0]) == 0:
+            return results
+
         full_box = torch.zeros_like(p[0][0])
         full_box[2], full_box[3], full_box[4], full_box[6:] = img.shape[3], img.shape[2], 1.0, 1.0
         full_box = full_box.view(1, -1)
@@ -30,7 +34,6 @@ class FastSAMPredictor(DetectionPredictor):
             full_box[0][6:] = p[0][critical_iou_index][:,6:]
             p[0][critical_iou_index] = full_box
         
-        results = []
         proto = preds[1][-1] if len(preds[1]) == 3 else preds[1]  # second output is len 3 if pt, but only 1 if exported
         for i, pred in enumerate(p):
             orig_img = orig_imgs[i] if isinstance(orig_imgs, list) else orig_imgs


### PR DESCRIPTION
With these changes, FastSAMPrompt can operate directly on numpy tensors, instead of having to pass a path to an image file. Everything should work exactly the same, except with new methods:

    class FastSAMPrompt:
    
        @staticmethod
        def from_np_tensor(img_tensor, results, device='cuda') -> 'FastSAMPrompt':

        def plot_to_result(self,
             annotations,
             bboxes=None,
             points=None,
             point_label=None,
             mask_random_color=True,
             better_quality=True,
             retina=False,
             withContours=True) -> np.ndarray:

Additionally, protect against a potential run-time bug in predict.py.