### PR TITLE
Fixed bbox in code demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ prompt_process = FastSAMPrompt(IMAGE_PATH, everything_results, device=DEVICE)
 ann = prompt_process.everything_prompt()
 
 # bbox default shape [0,0,0,0] -> [x1,y1,x2,y2]
-ann = prompt_process.box_prompt(bbox=[[200, 200, 300, 300]])
+ann = prompt_process.box_prompt(bbox=[200, 200, 300, 300])
 
 # text prompt
 ann = prompt_process.text_prompt(text='a photo of a dog')


### PR DESCRIPTION
When running the demo given in the README.md, I had this error:
```py
Traceback (most recent call last):
  File "FastSAM/tests.py", line 20, in <module>
    ann = prompt_process.box_prompt(bbox=[[200, 200, 300, 300]])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "FastSAM/fastsam/prompt.py", line 381, in box_prompt
    assert (bbox[2] != 0 and bbox[3] != 0)
            ~~~~^^^
IndexError: list index out of range
```

To fix it one can change the README.md demo code to either:
```py
ann = prompt_process.box_prompt(bbox=[200, 200, 300, 300])
```
or
```py
ann = prompt_process.box_prompt(bboxes=[[200, 200, 300, 300]])
```

This pull request contains the first fix (with single bbox).