### PR TITLE
Fixed decoder (encoder/decoder API) #111

### DIFF
--- a/fastsam/decoder.py
+++ b/fastsam/decoder.py
@@ -62,8 +62,8 @@ class FastSAMDecoder:
     def box_prompt(self, bbox):
         assert (bbox[2] != 0 and bbox[3] != 0)
         masks = self.image_embedding.masks.data
-        target_height = self.ori_img.shape[0]
-        target_width = self.ori_img.shape[1]
+        target_height = self.image.shape[0]
+        target_width = self.image.shape[1]
         h = masks.shape[1]
         w = masks.shape[2]
         if h != target_height or w != target_width:
@@ -91,9 +91,9 @@ class FastSAMDecoder:
 
     def point_prompt(self, points, pointlabel):  # numpy 
 
-        masks = self._format_results(self.results[0], 0)
-        target_height = self.ori_img.shape[0]
-        target_width = self.ori_img.shape[1]
+        masks = self._format_results(self.image_embedding[0], 0)
+        target_height = self.image.shape[0]
+        target_width = self.image.shape[1]
         h = masks[0]['segmentation'].shape[0]
         w = masks[0]['segmentation'].shape[1]
         if h != target_height or w != target_width:


### PR DESCRIPTION
I was trying to run this:

> We have released the API for FastSAM. Please see for details at fastsam/decoder.py.
> 
> import model 
> ```python
> from fastsam import FastSAM ,FastSAMDecoder
> model = FastSAM('./weights/FastSAM.pt')
> fastsam = FastSAMDecoder(model,device=DEVICE,retina_masks=True,imgsz=1024,conf=0.4,iou=0.9)
> ```
> Encoder
> ```Python
> image_embedding = fastsam.run_encoder(image)
> ```
> 
> Decoder
> ```Python
> ann = fastsam.run_decoder(image_embedding,point_prompt=[[506, 340]], point_label=[1])
> ```
> 
> _Originally posted by @YinglongDu in https://github.com/CASIA-IVA-Lab/FastSAM/issues/5#issuecomment-1609070378_

But I had some issues (see #111).

So I fixed the error `'FastSAMDecoder' object has no attribute 'results'` (see https://github.com/CASIA-IVA-Lab/FastSAM/issues/111) by replacing `results` with `image_embedding` (set in run_decoder [here](https://github.com/CASIA-IVA-Lab/FastSAM/blob/314d076624a528813e2f69e442ef26ee368969af/fastsam/decoder.py#L49)).

Also replaced `self.ori_img` with `self.image` as the class had no `ori_image` as well, `image` is set [here](https://github.com/CASIA-IVA-Lab/FastSAM/blob/314d076624a528813e2f69e442ef26ee368969af/fastsam/decoder.py#L24C15-L24C15).

Now this class is working fine without errors.