### PR TITLE
Add Autodistill integration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [[`📕Paper`](https://arxiv.org/pdf/2306.12156.pdf)] [[`🤗HuggingFace Demo`](https://huggingface.co/spaces/An-619/FastSAM)] [[`Colab demo`](https://colab.research.google.com/drive/1oX14f6IneGGw612WgVlAiy91UHwFAvr9?usp=sharing)] [[`Replicate demo & API`](https://replicate.com/casia-iva-lab/fastsam)] [[`OpenXLab Demo`](https://openxlab.org.cn/apps/detail/zxair/FastSAM)] [[`Model Zoo`](#model-checkpoints)] [[`BibTeX`](#citing-fastsam)]
 
+[[`Label Datasets Automatically with FastSAM`](https://github.com/autodistill/autodistill-fastsam)]
+
 ![FastSAM Speed](assets/head_fig.png)
 
 The **Fast Segment Anything Model(FastSAM)** is a CNN Segment Anything Model trained using only 2% of the SA-1B dataset published by SAM authors. FastSAM achieves comparable performance with


### PR DESCRIPTION
The Roboflow team created an extension to Autodistill that lets someone use FastSAM to automatically label data for use in training a computer vision model. [Autodistill](https://github.com/autodistill/autodistill) enables people to label datasets using foundation models and train models like FastSAM using state-of-the-art architectures like YOLOv8 and DETR

This PR adds a link to the Autodistill FastSAM project so people can use FastSAM to label data in a few lines of code.

I am excited to see people use FastSAM to train fine-tuned models!