### PR TITLE
Fix: rename prompt_process.plot output parameter to output_path

### DIFF
--- a/segpredict.py
+++ b/segpredict.py
@@ -44,7 +44,7 @@ ann = prompt_process.point_prompt(points=[[620, 360]], pointlabel=[1])
 
 prompt_process.plot(
     annotations=ann,
-    output='./output/',
+    output_path='./output/',
     mask_random_color=True,
     better_quality=True,
     retina=False,


### PR DESCRIPTION
This update fixes a bug caused by an unrecognized argument in the [prompt_process.plot output parameter](https://github.com/CASIA-IVA-Lab/FastSAM/blob/4d153e909f0ad9c8ecd7632566e5a24e21cf0071/fastsam/prompt.py#L194). To address this issue, the parameter has been renamed to output_path.