### PR TITLE
Fix example parameter errors in segpreict.py

### DIFF
--- a/segpredict.py
+++ b/segpredict.py
@@ -44,7 +44,7 @@ ann = prompt_process.point_prompt(points=[[620, 360]], pointlabel=[1])
 
 prompt_process.plot(
     annotations=ann,
-    output='./output/',
+    output_path='./output/output_dogs.jpg',
     mask_random_color=True,
     better_quality=True,
     retina=False,


### PR DESCRIPTION
When conducting research on fastsam, I wanted to use the ability of SamAutomaticMaskGenerator to generate multiple masks. I saw that prompt_process.everything_prompt combines all the mask fragments into one image. Is it possible to divide them into multiple images.