### PR TITLE
Minor import fix

### DIFF
--- a/fastsam/prompt.py
+++ b/fastsam/prompt.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import cv2
+import clip
 import matplotlib.pyplot as plt
 import numpy as np
 import torch


### PR DESCRIPTION
If you run the exampler command provided in the readme `$ python Inference.py --model_path ./weights/FastSAM.pt --img_path ./images/dogs.jpg  --text_prompt "the yellow dog"` then you will be getting this error:
```
0: 576x1024 21 objects, 309.2ms
Speed: 13.9ms preprocess, 309.2ms inference, 201.5ms postprocess per image at shape (1, 3, 1024, 1024)
Traceback (most recent call last):
  File "/home/janand/robot_hand_control/src/wrist/FastSegExp/FastSAM/Inference.py", line 122, in <module>
    main(args)
  File "/home/janand/robot_hand_control/src/wrist/FastSegExp/FastSAM/Inference.py", line 98, in main
    ann = prompt_process.text_prompt(text=args.text_prompt)
  File "/home/janand/robot_hand_control/src/wrist/FastSegExp/FastSAM/fastsam/prompt.py", line 445, in text_prompt
    clip_model, preprocess = clip.load('ViT-B/32', device=self.device)
NameError: name 'clip' is not defined
```

It seems like the `import clip` was missing from `fastsam/prompt.py`