### PR TITLE
Dependency versioning Update

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include ultralytics *.yaml
+recursive-include ultralytics *.txt
+recursive-include ultralytics *.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ tqdm>=4.64.0
 
 pandas>=1.1.4
 seaborn>=0.11.0
-
+psutil == 7.1.3
 gradio==3.35.2
 
 # Ultralytics-----------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ seaborn>=0.11.0
 gradio==3.35.2
 
 # Ultralytics-----------------------------------
-# ultralytics == 8.0.120
+ultralytics == 8.0.120
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ seaborn>=0.11.0
 gradio==3.35.2
 
 # Ultralytics-----------------------------------
-ultralytics == 8.0.120
+ultralytics == 8.3.255
+
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ seaborn>=0.11.0
 gradio==3.35.2
 
 # Ultralytics-----------------------------------
-ultralytics == 8.3.255
+ultralytics == 8.3.225
+
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ seaborn>=0.11.0
 gradio==3.35.2
 
 # Ultralytics-----------------------------------
-ultralytics == 8.0.120
+# ultralytics == 8.0.120
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,8 @@ setup(
             'ultralytics*',  # include ultralytics and all its subpackages
         ],
     ),
-    url="https://github.com/CASIA-IVA-Lab/FastSAM"
+    url="https://github.com/CASIA-IVA-Lab/FastSAM",
+    include_package_data=True,
+    package_data={'ultralytics': ['**/*.yaml', '**/*.txt', '**/*.json']}
+
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     package_dir= {
         "fastsam": "fastsam",
         "fastsam_tools": "utils",
-        "fastsam_ultralytics": "ultralytics
+        "fastsam_ultralytics": "ultralytics"
     },
     url="https://github.com/CASIA-IVA-Lab/FastSAM"
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=["fastsam", "fastsam_tools", "ultralytics"],
     package_dir= {
         "fastsam": "fastsam",
-        "fastsam_tools": "utils.*",
+        "fastsam_tools": "utils",
         "ultralytics": "ultralytics.*"
     },
     url="https://github.com/CASIA-IVA-Lab/FastSAM"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="fastsam",
     version="0.1.1",
     install_requires=REQUIREMENTS,
-    packages=["fastsam", "fastsam_tools"],
+    packages=["fastsam", "fastsam_tools", "ultralytics"],
     package_dir= {
         "fastsam": "fastsam",
         "fastsam_tools": "utils",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     package_dir= {
         "fastsam": "fastsam",
         "fastsam_tools": "utils",
-        "fastsam_ultralytics": "ultralytics"
+        "ultralytics": "ultralytics"
     },
     url="https://github.com/CASIA-IVA-Lab/FastSAM"
 )

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     package_dir= {
         "fastsam": "fastsam",
         "fastsam_tools": "utils",
+        "fastsam_ultralytics": "ultralytics
     },
     url="https://github.com/CASIA-IVA-Lab/FastSAM"
 )

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     packages=["fastsam", "fastsam_tools", "ultralytics"],
     package_dir= {
         "fastsam": "fastsam",
-        "fastsam_tools": "utils",
-        "ultralytics": "ultralytics"
+        "fastsam_tools": "utils.*",
+        "ultralytics": "ultralytics.*"
     },
     url="https://github.com/CASIA-IVA-Lab/FastSAM"
 )

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,13 @@ setup(
     name="fastsam",
     version="0.1.1",
     install_requires=REQUIREMENTS,
-    packages=["fastsam", "fastsam_tools", "ultralytics"],
-    package_dir= {
-        "fastsam": "fastsam",
-        "fastsam_tools": "utils",
-        "ultralytics": "ultralytics.*"
-    },
+    packages=find_packages(
+        where='.',
+        include=[
+            'fastsam',  # include only top-level fastsam
+            'utils',  # include only top-level utils
+            'ultralytics*',  # include ultralytics and all its subpackages
+        ],
+    ),
     url="https://github.com/CASIA-IVA-Lab/FastSAM"
 )

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -515,7 +515,7 @@ def torch_safe_load(weight):
     check_suffix(file=weight, suffix='.pt')
     file = attempt_download_asset(weight)  # search online if missing locally
     try:
-        return torch.load(file, map_location='cpu'), file  # load
+        return torch.load(file, map_location='cpu', weights_only=False), file  # load
     except ModuleNotFoundError as e:  # e.name is missing module name
         if e.name == 'models':
             raise TypeError(

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -530,7 +530,7 @@ def torch_safe_load(weight):
                        f"run a command with an official YOLOv8 model, i.e. 'yolo predict model=yolov8n.pt'")
         check_requirements(e.name)  # install missing module
 
-        return torch.load(file, map_location='cpu'), file  # load
+        return torch.load(file, map_location='cpu', weights_only=False), file  # load
 
 
 def attempt_load_weights(weights, device=None, inplace=True, fuse=False):


### PR DESCRIPTION
Some of the dependencies use deprecated package versions, despite working well with newer updates.
Beyond dependency updates, I have also changed 
``` 
return torch.load(file, map_location='cpu')
```
to 
``` 
return torch.load(file, map_location='cpu', weights_only=False)
```
because newer torch versions have weights_only = True as the default